### PR TITLE
Add extra metadata

### DIFF
--- a/src/adapters/helvetica-scans.test.js
+++ b/src/adapters/helvetica-scans.test.js
@@ -59,15 +59,19 @@ describe('HelveticaScans', () => {
         title: 'Talentless Nana',
         chapters: expect.arrayContaining([
           {
-            number: '1',
+            chapterNumber: '1',
+            volumeNumber: '1',
             createdAt: 1496705622,
             slug: 'en/1/1',
+            title: 'Talentless',
             url:
               'http://helveticascans.com/r/read/talentless-nana/en/1/1/page/1',
           },
           {
-            number: '8',
+            chapterNumber: '8',
+            volumeNumber: '2',
             createdAt: 1507488334,
+            title: 'Prophetic Dreams Part 3',
             slug: 'en/2/8',
             url:
               'http://helveticascans.com/r/read/talentless-nana/en/2/8/page/1',

--- a/src/adapters/hot-chocolate-scans.test.js
+++ b/src/adapters/hot-chocolate-scans.test.js
@@ -19,23 +19,23 @@ describe('HotChocolateScansAdapter', () => {
   describe('parseUrl', () => {
     it('returns the components of a url', () => {
       expect(
-        site.parseUrl('http://hotchocolatescans.com/fs/series/itoshi-no-muco/'),
+        site.parseUrl('http://hotchocolatescans.com/fs/series/series-slug/'),
       ).toEqual({
-        seriesSlug: 'itoshi-no-muco',
+        seriesSlug: 'series-slug',
         chapterSlug: null,
       });
 
       expect(
         site.parseUrl(
-          'http://hotchocolatescans.com/fs/read/itoshi-no-muco/en/1/2/page/1',
+          'http://hotchocolatescans.com/fs/read/series-slug/en/1/2/page/1',
         ),
-      ).toEqual({ seriesSlug: 'itoshi-no-muco', chapterSlug: 'en/1/2' });
+      ).toEqual({ seriesSlug: 'series-slug', chapterSlug: 'en/1/2' });
 
       expect(
         site.parseUrl(
-          'http://hotchocolatescans.com/fs/read/mousou-telepathy/en/0/512/5/page/25',
+          'http://hotchocolatescans.com/fs/read/series-slug/en/0/512/5/page/25',
         ),
-      ).toEqual({ seriesSlug: 'mousou-telepathy', chapterSlug: 'en/0/512/5' });
+      ).toEqual({ seriesSlug: 'series-slug', chapterSlug: 'en/0/512/5' });
     });
 
     it('throws on unparseable paths', () => {
@@ -61,16 +61,20 @@ describe('HotChocolateScansAdapter', () => {
         title: 'Watashi no Shounen',
         chapters: expect.arrayContaining([
           {
-            number: '4',
+            chapterNumber: '4',
+            volumeNumber: '0',
             createdAt: 1516818687,
             slug: 'en/0/4',
+            title: 'A Present',
             url:
               'http://hotchocolatescans.com/fs/read/watashi_no_shounen/en/0/4/page/1',
           },
           {
-            number: '8',
+            chapterNumber: '8',
+            volumeNumber: '0',
             createdAt: 1518828182,
             slug: 'en/0/8',
+            title: 'Water and Light',
             url:
               'http://hotchocolatescans.com/fs/read/watashi_no_shounen/en/0/8/page/1',
           },

--- a/src/adapters/jaiminis-box.js
+++ b/src/adapters/jaiminis-box.js
@@ -54,9 +54,17 @@ const JaiminisBoxAdapter = {
     const chapters: ChapterMetadata[] = chapterNodes.get().map(el => {
       const node = dom(el);
 
-      const url = node.find('.title a').attr('href');
+      const link = node.find('.title a');
+
+      const url = link.attr('href');
+      const title = link.attr('title').split(': ')[1];
+
       const slug = this.parseUrl(url).chapterSlug.replace(/\/$/, '');
-      const number = slug.split('/')[2];
+
+      const slugParts = slug.split('/');
+      const volumeNumber = slugParts[1];
+      const chapterNumber = slugParts[2];
+
       const createdAtRawText = node
         .find('.meta_r')
         .text()
@@ -67,9 +75,8 @@ const JaiminisBoxAdapter = {
       );
       const createdAt = getTimestamp(createdAtParsedText);
 
-      return { url, slug, number, createdAt };
+      return { url, title, slug, chapterNumber, volumeNumber, createdAt };
     });
-    const updatedAt = 0;
 
     return { slug: seriesSlug, url, title, chapters };
   },

--- a/src/adapters/jaiminis-box.test.js
+++ b/src/adapters/jaiminis-box.test.js
@@ -59,15 +59,19 @@ describe('JaiminisBoxAdapter', () => {
         title: 'Itoshi no Muco',
         chapters: expect.arrayContaining([
           {
-            number: '4',
+            chapterNumber: '4',
+            volumeNumber: '0',
             createdAt: 1483516800,
             slug: 'en/0/4',
+            title: 'Walk!',
             url: 'https://jaiminisbox.com/reader/read/itoshi-no-muco/en/0/4/',
           },
           {
-            number: '8',
+            chapterNumber: '8',
+            volumeNumber: '0',
             createdAt: 1487750400,
             slug: 'en/0/8',
+            title: 'Friend!',
             url: 'https://jaiminisbox.com/reader/read/itoshi-no-muco/en/0/8/',
           },
         ]),

--- a/src/adapters/mangadex.js
+++ b/src/adapters/mangadex.js
@@ -72,7 +72,9 @@ const extractChapters = (
     }
 
     const duplicateChapters = arr.filter(
-      d => d.volumeNumber === data.volumeNumber && d.chapterNumber === data.chapterNumber,
+      d =>
+        d.volumeNumber === data.volumeNumber &&
+        d.chapterNumber === data.chapterNumber,
     );
 
     if (duplicateChapters.length > 1) {
@@ -82,10 +84,7 @@ const extractChapters = (
     return true;
   });
 
-  return filteredChapterData.map(({ language, views, chapterNumber, ...rest }) => ({
-    ...rest,
-    number: chapterNumber,
-  }));
+  return filteredChapterData.map(({ language, views, ...rest }) => rest);
 };
 
 const MangadexAdapter: SiteAdapter = {
@@ -101,7 +100,10 @@ const MangadexAdapter: SiteAdapter = {
   },
 
   parseUrl(url) {
-    const matches = utils.pathMatch(url, '/:type(manga|chapter)/:first/:second?');
+    const matches = utils.pathMatch(
+      url,
+      '/:type(manga|chapter)/:first/:second?',
+    );
 
     invariant(matches, new errors.InvalidUrlError(url));
     invariant(matches.first, new errors.InvalidUrlError(url));
@@ -117,7 +119,10 @@ const MangadexAdapter: SiteAdapter = {
     const type = chapterSlug ? 'chapter' : 'manga';
     const slug = type === 'chapter' ? chapterSlug : seriesSlug;
 
-    invariant(slug, new TypeError('Either series slug or chapter slug must be non-null'));
+    invariant(
+      slug,
+      new TypeError('Either series slug or chapter slug must be non-null'),
+    );
 
     return utils.normalizeUrl(`https://mangadex.org/${type}/${slug}`);
   },
@@ -140,9 +145,15 @@ const MangadexAdapter: SiteAdapter = {
     const author = metadataTable.find('tr:nth-child(2) > td').text();
 
     const statusElement = metadataTable.find('tr:nth-child(7) > td');
-    const status = statusElement.text().toLowerCase() === 'ongoing' ? 'ongoing' : 'completed';
+    const status =
+      statusElement.text().toLowerCase() === 'ongoing'
+        ? 'ongoing'
+        : 'completed';
 
-    const chapterPaginationElement = dom('.table-responsive + p', '.edit.tab-content').first();
+    const chapterPaginationElement = dom(
+      '.table-responsive + p',
+      '.edit.tab-content',
+    ).first();
     const chapterPaginationText = chapterPaginationElement.text().trim();
     const hasPagination = chapterPaginationText.length > 0;
 
@@ -151,7 +162,10 @@ const MangadexAdapter: SiteAdapter = {
     let chapters: ChapterMetadata[] = extractChapters(html, getChapterUrl);
 
     if (hasPagination) {
-      const chapterCount = parseInt(chapterPaginationText.split(' of ').pop(), 10);
+      const chapterCount = parseInt(
+        chapterPaginationText.split(' of ').pop(),
+        10,
+      );
       const pagesPerChapter = 100;
       const pageCount = Math.ceil(chapterCount / pagesPerChapter);
       const pageUrls = utils
@@ -176,7 +190,10 @@ const MangadexAdapter: SiteAdapter = {
 
     const imageServer = utils.extractJSON(/var\s+server\s+=\s+(.+);/, html);
     const hash = utils.extractJSON(/var\s+dataurl\s+=\s+(.+);/, html);
-    const pagesJson = utils.extractJSON(/var\s+page_array\s+=\s+([^;]+);/, html);
+    const pagesJson = utils.extractJSON(
+      /var\s+page_array\s+=\s+([^;]+);/,
+      html,
+    );
 
     // NOTE: some series are hosted on the main server. We check if it's a
     // relative URL and make sure it has a host before using it.

--- a/src/adapters/mangadex.test.js
+++ b/src/adapters/mangadex.test.js
@@ -42,16 +42,22 @@ describe('MangadexAdapter', () => {
         slug: '13127',
         url: 'https://mangadex.org/manga/13127',
         title: 'Uramikoi, Koi, Uramikoi.',
+        author: 'Akitaka',
+        status: 'ongoing',
         chapters: expect.arrayContaining([
           {
             slug: '37060',
-            number: '2',
+            chapterNumber: '2',
+            volumeNumber: '1',
+            title: 'A Cornered Rat Will Even Bite a Rat',
             url: 'https://mangadex.org/chapter/37060',
             createdAt: 1517704912,
           },
           {
             slug: '37348',
-            number: 'Oneshot',
+            chapterNumber: 'Oneshot',
+            volumeNumber: '0',
+            title: 'Oneshot',
             url: 'https://mangadex.org/chapter/37348',
             createdAt: 1517709152,
           },
@@ -69,7 +75,8 @@ describe('MangadexAdapter', () => {
       const seriesWithMultipleGroups = await site.getSeries('19729');
       const seriesWithMultipleVolumes = await site.getSeries('13025');
 
-      const getChapterNumbers = series => series.chapters.map(c => c.number);
+      const getChapterNumbers = series =>
+        series.chapters.map(c => c.chapterNumber);
       const uniq = arr => Array.from(new Set(arr));
 
       const a = getChapterNumbers(seriesWithMultipleGroups);

--- a/src/adapters/mangakakalot.test.js
+++ b/src/adapters/mangakakalot.test.js
@@ -37,9 +37,10 @@ describe('MangakakalotAdapter', () => {
         title: 'Urami Koi, Koi, Urami Koi.',
         chapters: expect.arrayContaining([
           {
-            number: '38',
+            chapterNumber: '38',
             createdAt: 1514196540,
             slug: 'chapter_38',
+            title: undefined,
             url:
               'http://mangakakalot.com/chapter/urami_koi_koi_urami_koi/chapter_38',
           },

--- a/src/adapters/meraki-scans.js
+++ b/src/adapters/meraki-scans.js
@@ -78,6 +78,12 @@ const MerakiScansAdapter: SiteAdapter = {
     invariant(title, new errors.NotFoundError(seriesUrl));
 
     const chapters: Array<ChapterMetadata> = rssChapters.get().map(el => {
+      // NOTE: Meraki returns RSS titles like this "Senryu Girl - 27 - Nanako and Cooking Class"
+      // so we split on the divider and look for the last element.
+      const title = xml(el)
+        .find('title')
+        .text()
+        .split(' - ')[2];
       const createdAtText = xml(el)
         .find('pubDate')
         .text();
@@ -90,9 +96,11 @@ const MerakiScansAdapter: SiteAdapter = {
         .tz(createdAtText, 'dddd, D MMM YYYY, HH:mm:ss', 'America/Los_Angeles')
         .unix();
       const slug = utils.extractText(/\/([\d\.]+)\/\d+\/?$/, chapterSlugText);
+      const chapterNumber = slug;
+      // NOTE: no concept of volumes on Meraki Scans
       const url = this.constructUrl(seriesSlug, slug);
 
-      return { slug, number: slug, url, createdAt };
+      return { slug, chapterNumber, title, url, createdAt };
     });
 
     return { slug: seriesSlug, url: seriesUrl, title, chapters };

--- a/src/adapters/meraki-scans.test.js
+++ b/src/adapters/meraki-scans.test.js
@@ -40,7 +40,8 @@ describe('MerakiScansAdapter', () => {
         chapters: expect.arrayContaining([
           {
             slug: '21',
-            number: '21',
+            chapterNumber: '21',
+            title: 'You are just!',
             url: 'http://merakiscans.com/ninja-shinobu-san-no-junjou/21',
             createdAt: 1505006721,
           },

--- a/src/adapters/shared/fool-slide.js
+++ b/src/adapters/shared/fool-slide.js
@@ -78,6 +78,7 @@ export default function makeFoolSlideAdapter(options: Options): SiteAdapter {
         const subchapter =
           data.chapter.subchapter === '0' ? null : data.chapter.subchapter;
 
+        const title = data.chapter.name;
         const slug = [
           data.chapter.language,
           data.chapter.volume,
@@ -95,7 +96,14 @@ export default function makeFoolSlideAdapter(options: Options): SiteAdapter {
           .tz(data.chapter.created, options.timeZone)
           .unix();
 
-        return { url, slug, number, createdAt };
+        return {
+          slug,
+          chapterNumber: data.chapter.chapter,
+          volumeNumber: data.chapter.volume,
+          title,
+          url,
+          createdAt,
+        };
       });
 
       return { slug: seriesSlug, url, title, chapters };

--- a/src/adapters/shared/mangakakalot.js
+++ b/src/adapters/shared/mangakakalot.js
@@ -135,16 +135,13 @@ export default function makeMangakakalotAdapter({
       const chapterRawData = dom('.row', '.chapter-list')
         .get()
         .map(el => {
-          const number = extractChapterNumber(
-            dom('a', el)
-              .text()
-              .trim(),
-          );
-          const href = dom('a', el).attr('href');
-          const slug = dom('a', el)
-            .attr('href')
-            .split('/')
-            .pop();
+          const link = dom('a', el);
+
+          const title = link.text().split(' : ')[1];
+          const chapterNumber = extractChapterNumber(link.text().trim());
+          // NOTE: no consistent concept of volumes on Mangakakalot
+          const href = link.attr('href');
+          const slug = href.split('/').pop();
           const url = this.constructUrl(seriesSlug, slug);
 
           let createdAtText = normalizeTimestampFormat(
@@ -154,7 +151,13 @@ export default function makeMangakakalotAdapter({
               .trim(),
           );
 
-          return { slug, url, number, createdAtText };
+          return {
+            slug,
+            url,
+            title,
+            chapterNumber,
+            createdAtText,
+          };
         });
 
       // NOTE: since Mangakakalot doesn't give the year with a chapter timestamp,
@@ -167,7 +170,7 @@ export default function makeMangakakalotAdapter({
       const chapters: Array<ChapterMetadata> = chapterRawData.map(
         (chapterData, i, arr) => {
           const prev = arr[i - 1];
-          const { createdAtText, slug, number, url } = chapterData;
+          const { createdAtText, ...rest } = chapterData;
 
           let createdAt = getUnixFromTimestamp(lastUpdatedYear, createdAtText);
 
@@ -186,7 +189,7 @@ export default function makeMangakakalotAdapter({
             }
           }
 
-          return { slug, url, number, createdAt };
+          return { ...rest, createdAt };
         },
       );
 

--- a/src/index.js
+++ b/src/index.js
@@ -39,8 +39,8 @@ function getAdapterBySiteId(siteId: string): SiteAdapter {
 }
 
 function sortChapters(a: ChapterMetadata, b: ChapterMetadata): number {
-  const numberA = parseFloat(a.number);
-  const numberB = parseFloat(b.number);
+  const numberA = parseFloat(a.chapterNumber);
+  const numberB = parseFloat(b.chapterNumber);
 
   if (Number.isNaN(numberB)) {
     return -1;

--- a/src/types.js
+++ b/src/types.js
@@ -29,11 +29,14 @@ export type Chapter = {
   pages: Array<Page>,
 };
 
+export type SeriesStatus = 'ongoing' | 'completed';
+
 export type Series = {
   id: string,
   slug: string,
   url: string,
   title: string,
+  status: SeriesStatus,
   chapters?: ChapterMetadata[],
   updatedAt: number,
 };
@@ -44,15 +47,15 @@ export type SiteAdapter = {
   constructUrl: (seriesSlug: ?string, chapterSlug: ?string) => string,
   supportsUrl: (url: string) => boolean,
   supportsReading: () => boolean,
-  parseUrl: (
-    url: string,
-  ) => { seriesSlug: string | null, chapterSlug: string | null },
+  parseUrl: (url: string) => { seriesSlug: string | null, chapterSlug: string | null },
   getSeries: (
     seriesSlug: string,
   ) => Promise<{
     slug: string,
     url: string,
     title: string,
+    author: string,
+    status: SeriesStatus,
     chapters?: ChapterMetadata[],
     updatedAt?: number,
   }>,

--- a/src/types.js
+++ b/src/types.js
@@ -18,8 +18,9 @@ type BaseChapter = {
 
 export type ChapterMetadata = {
   ...BaseChapter,
-  title: string,
-  number: ?string,
+  title?: string,
+  chapterNumber?: string,
+  volumeNumber?: string,
   createdAt: number,
 };
 
@@ -29,14 +30,11 @@ export type Chapter = {
   pages: Array<Page>,
 };
 
-export type SeriesStatus = 'ongoing' | 'completed';
-
 export type Series = {
   id: string,
   slug: string,
   url: string,
   title: string,
-  status: SeriesStatus,
   chapters?: ChapterMetadata[],
   updatedAt: number,
 };
@@ -47,15 +45,15 @@ export type SiteAdapter = {
   constructUrl: (seriesSlug: ?string, chapterSlug: ?string) => string,
   supportsUrl: (url: string) => boolean,
   supportsReading: () => boolean,
-  parseUrl: (url: string) => { seriesSlug: string | null, chapterSlug: string | null },
+  parseUrl: (
+    url: string,
+  ) => { seriesSlug: string | null, chapterSlug: string | null },
   getSeries: (
     seriesSlug: string,
   ) => Promise<{
     slug: string,
     url: string,
     title: string,
-    author: string,
-    status: SeriesStatus,
     chapters?: ChapterMetadata[],
     updatedAt?: number,
   }>,


### PR DESCRIPTION
This PR introduces extra fields to the Poketo series and chapter responses to enable several new features on the Poketo reader.

- [ ] ~Series status (ongoing vs. completed)~
- [x] Volume numbers
- [x] Chapter numbers
- [x] Chapter titles (beyond just numbers)
- [ ] ~Chapter preview images (ie. volume covers)~
- [ ] ~Author names~