### PR TITLE
Add supports for Manga Stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,14 @@ console.log(chapter);
 | Mangadex            | https://mangadex.org           | ✓        | ✓             |
 | Mangakakalot        | http://mangakakalot.com        | ✓        | ✓             |
 | Manganelo           | http://manganelo.com           | ✓        | ✓             |
+| MangaStream         | https://readms.net             | ✓        | ✓             |
 | Meraki Scans        | http://merakiscans.com         | ✓        | ✓             |
 | Phoenix Serenade    | https://serenade.moe           | ✓        | ✓             |
 | Sense Scans         | https://sensescans.com/        | ✓        | ✓             |
 | Silent Sky Scans    | http://www.silentsky-scans.net | ✓        | ✓             |
 | Tuki Scans          | https://tukimoop.pw            | ✓        | ✓             |
 
-If there's a site / group you'd like to see supported, [make an issue!](https://github.com/poketo/lib/issues/new)
+If there's a site / group you'd like to see supported, [make an issue!](https://github.com/poketo/poketo/issues/new)
 
 ### API
 

--- a/src/adapters/__snapshots__/manga-stream.test.js.snap
+++ b/src/adapters/__snapshots__/manga-stream.test.js.snap
@@ -1,0 +1,182 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MangaStreamAdapter getChapter returns a list of pages 1`] = `
+Array [
+  Object {
+    "height": 1200,
+    "id": "01.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/01.png",
+    "width": 789,
+  },
+  Object {
+    "height": 800,
+    "id": "01a.jpg",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/01a.jpg",
+    "width": 800,
+  },
+  Object {
+    "height": 1200,
+    "id": "02.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/02.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "03.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/03.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "04.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/04.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "05.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/05.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "06.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/06.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "07.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/07.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "08.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/08.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "09.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/09.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "10.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/10.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "11.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/11.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "12.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/12.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "13.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/13.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "14-15.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/14-15.png",
+    "width": 1581,
+  },
+  Object {
+    "height": 1200,
+    "id": "16.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/16.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "17.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/17.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "18.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/18.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "19.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/19.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "20.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/20.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "21.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/21.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "22.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/22.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "23.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/23.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "24.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/24.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "25.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/25.png",
+    "width": 789,
+  },
+  Object {
+    "height": 1200,
+    "id": "261.png",
+    "url": "https://img.mangastream.com/cdn/manga/149/4622/261.png",
+    "width": 789,
+  },
+]
+`;
+
+exports[`MangaStreamAdapter getSeries returns a metadata object 1`] = `
+Object {
+  "slug": "shokugeki_no_souma",
+  "title": "Shokugeki no Souma",
+  "url": "https://readms.net/manga/shokugeki_no_souma",
+}
+`;
+
+exports[`MangaStreamAdapter getSeries returns a metadata object 2`] = `
+Array [
+  Object {
+    "chapterNumber": "264",
+    "createdAt": 1527206400,
+    "slug": "264/5101",
+    "title": "From: Tadokoro Megumi",
+    "url": "https://readms.net/r/shokugeki_no_souma/264/5101",
+  },
+]
+`;

--- a/src/adapters/index.js
+++ b/src/adapters/index.js
@@ -9,6 +9,7 @@ import MangaUpdatesAdapter from './manga-updates';
 import MangadexAdapter from './mangadex';
 import MangakakalotAdapter from './mangakakalot';
 import ManganeloAdapter from './manganelo';
+import MangaStreamAdapter from './manga-stream';
 import MerakiScansAdapter from './meraki-scans';
 import PhoenixSerenadeAdapter from './phoenix-serenade';
 import SenseScansAdapter from './sense-scans';

--- a/src/adapters/manga-stream.js
+++ b/src/adapters/manga-stream.js
@@ -39,7 +39,7 @@ const getChapterSlugFromPathname = pathname =>
 const getPageNumberFromPathname = pathname =>
   parseFloat(pathname.split('/').pop());
 
-const getPageFromHTML = async html => {
+const getPageFromHtml = async html => {
   const dom = cheerio.load(html);
   const src = dom('img#manga-page').attr('src');
   const normalizedSrc = src.startsWith('//') ? `https:${src}` : src;
@@ -54,7 +54,7 @@ const getPageFromHTML = async html => {
   };
 };
 
-const getPageFromURL = url => throttledGet(url).then(getPageFromHTML);
+const getPageFromUrl = url => throttledGet(url).then(getPageFromHtml);
 
 const stripLeadingZeroes = str => str.replace(/^0+/, '');
 const stripEndMarker = str => str.replace(/ [\(\[]?end[\)\]]?$/i, '');
@@ -158,7 +158,7 @@ const MangaStreamAdapter: SiteAdapter = {
       .range(firstPageNumber, lastPageNumber)
       .map(getPageUrl);
 
-    const pages = await Promise.all(pageUrls.map(url => getPageFromURL(url)));
+    const pages = await Promise.all(pageUrls.map(url => getPageFromUrl(url)));
 
     return { slug: chapterSlug, url, pages };
   },

--- a/src/adapters/manga-stream.js
+++ b/src/adapters/manga-stream.js
@@ -1,0 +1,167 @@
+// @flow
+
+import cheerio from 'cheerio';
+import moment from 'moment-timezone';
+import throttle from 'p-throttle';
+import errors from '../errors';
+import utils, { invariant } from '../utils';
+import type { SiteAdapter } from '../types';
+
+const TZ = 'UTC';
+const throttledGet = throttle(utils.getPage, 5, 100);
+
+const getChapterTimestamp = str => {
+  let date;
+
+  switch (str.toLowerCase()) {
+    case 'today':
+      date = moment.tz(TZ);
+      break;
+    case 'yesterday':
+      date = moment.tz(TZ).subtract(1, 'day');
+      break;
+    case '2 days ago':
+      date = moment.tz(TZ).subtract(2, 'days');
+      break;
+    default:
+      date = moment.tz(str, 'MMM Do, YYYY', TZ);
+      break;
+  }
+
+  return date.startOf('day').unix();
+};
+const getChapterSlugFromPathname = pathname =>
+  pathname
+    .split('/')
+    .filter(Boolean)
+    .slice(2, 4)
+    .join('/');
+const getPageNumberFromPathname = pathname =>
+  parseFloat(pathname.split('/').pop());
+
+const getPageFromHTML = async html => {
+  const dom = cheerio.load(html);
+  const src = dom('img#manga-page').attr('src');
+  const normalizedSrc = src.startsWith('//') ? `https:${src}` : src;
+
+  const { width, height } = await utils.getImageSize(normalizedSrc);
+
+  return {
+    id: normalizedSrc.split('/').pop(),
+    url: normalizedSrc,
+    width,
+    height,
+  };
+};
+
+const getPageFromURL = url => throttledGet(url).then(getPageFromHTML);
+
+const stripLeadingZeroes = str => str.replace(/^0+/, '');
+const stripEndMarker = str => str.replace(/ [\(\[]?end[\)\]]?$/i, '');
+const trimChapterNumber = str => {
+  return stripEndMarker(stripLeadingZeroes(str));
+};
+
+const MangaStreamAdapter: SiteAdapter = {
+  id: 'manga-stream',
+  name: 'Manga Stream',
+
+  supportsUrl(url) {
+    return utils.compareDomain(url, 'https://readms.net');
+  },
+
+  supportsReading() {
+    return true;
+  },
+
+  parseUrl(url) {
+    // https://readms.net/manga/attack_on_titan
+    // https://readms.net/r/attack_on_titan/103/4949/3
+
+    const u = utils.parseUrl(url);
+    const parts = u.pathname.split('/').filter(Boolean);
+    const isChapter = u.pathname.startsWith('/r/');
+
+    invariant(parts.length > 1, new errors.InvalidUrlError(url));
+
+    let seriesSlug = parts[1];
+    let chapterSlug = null;
+
+    if (isChapter) {
+      invariant(parts.length > 3, new errors.InvalidUrlError(url));
+      chapterSlug = getChapterSlugFromPathname(u.pathname);
+    }
+
+    return { seriesSlug, chapterSlug };
+  },
+
+  constructUrl(seriesSlug, chapterSlug) {
+    const initial = chapterSlug ? 'r' : 'manga';
+    const slug = [initial, seriesSlug, chapterSlug].filter(Boolean).join('/');
+
+    return utils.normalizeUrl(`https://readms.net/${slug}`);
+  },
+
+  async getSeries(seriesSlug) {
+    const url = this.constructUrl(seriesSlug);
+
+    const html = await throttledGet(url);
+    const dom = cheerio.load(html);
+
+    const title = dom('.main-body h1')
+      .text()
+      .trim();
+
+    // NOTE: MangaStream returns a 200 status for all pages, even when the
+    // slug doesn't exist. The "Page Not Found" h1 tag is our clue it's a 404.
+    invariant(title !== 'Page Not Found', new errors.NotFoundError(url));
+
+    const chapters = dom('.main-body h1 + table.table tr')
+      .slice(1) // skip the header row
+      .get()
+      .map(el => {
+        const row = dom(el);
+
+        const link = row.find('td > a');
+        const right = row.find('td:last-child');
+
+        const titleParts = link.text().split(' - ');
+        const chapterNumber = trimChapterNumber(titleParts[0]);
+        const title = titleParts[1];
+
+        const slug = getChapterSlugFromPathname(link.attr('href'));
+        const url = this.constructUrl(seriesSlug, slug);
+        const createdAt = getChapterTimestamp(right.text());
+
+        return { slug, title, url, createdAt, chapterNumber };
+      });
+
+    return { slug: seriesSlug, url, title, chapters };
+  },
+
+  async getChapter(seriesSlug, chapterSlug) {
+    const url = this.constructUrl(seriesSlug, chapterSlug);
+
+    const html = await utils.getPage(url);
+    const dom = cheerio.load(html);
+
+    const pageLinkList = dom('.btn-reader-page ul.dropdown-menu li a');
+    const firstPagePathname = pageLinkList.first().attr('href');
+    const lastPagePathname = pageLinkList.last().attr('href');
+
+    const firstPageNumber = getPageNumberFromPathname(firstPagePathname);
+    const lastPageNumber = getPageNumberFromPathname(lastPagePathname);
+
+    const getPageUrl = pageNumber =>
+      `${this.constructUrl(seriesSlug, chapterSlug)}/${pageNumber}`;
+    const pageUrls = utils
+      .range(firstPageNumber, lastPageNumber)
+      .map(getPageUrl);
+
+    const pages = await Promise.all(pageUrls.map(url => getPageFromURL(url)));
+
+    return { slug: chapterSlug, url, pages };
+  },
+};
+
+export default MangaStreamAdapter;

--- a/src/adapters/manga-stream.test.js
+++ b/src/adapters/manga-stream.test.js
@@ -1,0 +1,64 @@
+import site from './manga-stream';
+import errors from '../errors';
+
+describe('MangaStreamAdapter', () => {
+  describe('parseUrl', () => {
+    it('returns the components of a url', () => {
+      expect(site.parseUrl('https://readms.net/manga/attack_on_titan')).toEqual(
+        {
+          seriesSlug: 'attack_on_titan',
+          chapterSlug: null,
+        },
+      );
+
+      expect(
+        site.parseUrl('https://readms.net/r/attack_on_titan/103/4949/3'),
+      ).toEqual({
+        seriesSlug: 'attack_on_titan',
+        chapterSlug: '103/4949',
+      });
+    });
+
+    it('throws on unparseable urls', () => {
+      expect(() => {
+        site.parseUrl('https://readms.net/about');
+      }).toThrow(errors.InvalidUrlError);
+    });
+  });
+
+  describe('constructUrl', () => {
+    it('returns a valid url', () => {
+      expect(site.constructUrl('attack_on_titan')).toEqual(
+        'https://readms.net/manga/attack_on_titan',
+      );
+
+      expect(site.constructUrl('attack_on_titan', '103/4949')).toEqual(
+        'https://readms.net/r/attack_on_titan/103/4949',
+      );
+    });
+  });
+
+  describe('getSeries', async () => {
+    it('returns a metadata object', async () => {
+      const { chapters, ...metadata } = await site.getSeries(
+        'shokugeki_no_souma',
+      );
+
+      expect(metadata).toMatchSnapshot();
+
+      const chapterNumbersToTest = ['264'];
+      const chaptersToTest = chapters.filter(chapter =>
+        chapterNumbersToTest.includes(chapter.chapterNumber),
+      );
+      expect(chaptersToTest).toMatchSnapshot();
+    });
+  });
+
+  describe('getChapter', async () => {
+    it('returns a list of pages', async () => {
+      const chapter = await site.getChapter('a_trail_of_blood', '15/4622');
+
+      expect(chapter.pages).toMatchSnapshot();
+    });
+  });
+});

--- a/src/adapters/mangadex.js
+++ b/src/adapters/mangadex.js
@@ -171,9 +171,8 @@ const MangadexAdapter: SiteAdapter = {
       const pagesPerChapter = 100;
       const pageCount = Math.ceil(chapterCount / pagesPerChapter);
       const pageUrls = utils
-        .range(pageCount)
-        .slice(1) // we already fetched the first page
-        .map(pageNumber => pageNumber + 1) // pages are 1-indexed
+        // 2, since we already fetched the first page
+        .range(2, pageCount - 1)
         .map(page => getPaginatedSeriesUrl(url, page));
 
       const pages = await Promise.all(pageUrls.map(url => throttledGet(url)));

--- a/src/utils.js
+++ b/src/utils.js
@@ -32,8 +32,12 @@ export default {
     return [].concat(...arr);
   },
 
-  range(length: number): number[] {
-    return [...Array(length).keys()];
+  range(low: number, high: number): number[] {
+    const result = [];
+    for (let i = low; i <= high; i++) {
+      result.push(i);
+    }
+    return result;
   },
 
   isNumber(val: mixed): boolean {


### PR DESCRIPTION
Adds an adapter to support <https://readms.net>, a host and scanlation group for a couple series that are hard to find elsewhere, such as [A Trail of Blood](https://mangadex.org/manga/20879/a-trail-of-blood), which was requested in the beta.