### PR TITLE
Fix MangaHere Description

### DIFF
--- a/src/adapters/manga-here.js
+++ b/src/adapters/manga-here.js
@@ -186,7 +186,7 @@ const MangaHereAdapter: SiteAdapter = {
     const dom = cheerio.load(html);
 
     const title = t(dom('.detail-info-right-title-font'));
-    const description = t(dom('.detail-info-right-content'));
+    const description = t(dom('.fullcontent'));
 
     const author = utils.formatAuthors([t(dom('.detail-info-right-say > a'))]);
     const status = utils.parseStatus(t(dom('.detail-info-right-title-tip')));


### PR DESCRIPTION
Using `.detail-info-right-content` will only load a short description, mangahere hides the rest in a hidden element `.fullcontent` for whatever reason, a simple change in the css selector and it works with no issues.

Made the change with github web edit because I'm too lazy to fork it and make changes, so hopefully the formatting doesn't get broken.